### PR TITLE
fix: server is not started when game is save is locked

### DIFF
--- a/BuddySave.UnitTests/Core/GamingSessionTests.cs
+++ b/BuddySave.UnitTests/Core/GamingSessionTests.cs
@@ -76,6 +76,49 @@ public class GamingSessionTests
         // Assert
         processProviderMock.Verify(x => x.Start(It.IsAny<ProcessStartInfo>()), Times.Never());
     }
+    
+    [Theory]
+    [InlineAutoMoqData(OrchestratorResult.SaveLocked)]
+    [InlineAutoMoqData(OrchestratorResult.Failed)]
+    public async Task Run_DoesWaitForServerToStop_WhenGameSaveIsNotLoaded(
+        OrchestratorResult orchestratorResult,
+        [Frozen] Mock<ISharedSaveOrchestrator> sharedSaveOrchestratorMock,
+        [Frozen] Mock<IProcessProvider> processProviderMock,
+        GameSave gameSave,
+        Session session,
+        ServerParameters serverParameters,
+        GamingSession sut)
+    {
+        // Arrange
+        sharedSaveOrchestratorMock.Setup(x => x.Load(It.IsAny<GameSave>(), It.IsAny<Session>())).ReturnsAsync(orchestratorResult);
+
+        // Act
+        await sut.RunServerWithAutoSave(gameSave, session, serverParameters);
+        
+        // Assert
+        processProviderMock.Verify(x => x.WaitForExitAsync(It.IsAny<Process>()), Times.Never());
+    }
+    
+    [Theory]
+    [InlineAutoMoqData(OrchestratorResult.SaveLocked)]
+    [InlineAutoMoqData(OrchestratorResult.Failed)]
+    public async Task Run_DoesNotCallSave_WhenGameSaveIsNotLoaded(
+        OrchestratorResult orchestratorResult,
+        [Frozen] Mock<ISharedSaveOrchestrator> sharedSaveOrchestratorMock,
+        GameSave gameSave,
+        Session session,
+        ServerParameters serverParameters,
+        GamingSession sut)
+    {
+        // Arrange
+        sharedSaveOrchestratorMock.Setup(x => x.Load(It.IsAny<GameSave>(), It.IsAny<Session>())).ReturnsAsync(orchestratorResult);
+
+        // Act
+        await sut.RunServerWithAutoSave(gameSave, session, serverParameters);
+        
+        // Assert
+        sharedSaveOrchestratorMock.Verify(x => x.Save(It.IsAny<GameSave>(), It.IsAny<Session>()), Times.Never());
+    }
 
     [Theory]
     [AutoMoqData]

--- a/BuddySave.UnitTests/Core/GamingSessionTests.cs
+++ b/BuddySave.UnitTests/Core/GamingSessionTests.cs
@@ -56,6 +56,28 @@ public class GamingSessionTests
     }
 
     [Theory]
+    [InlineAutoMoqData(OrchestratorResult.SaveLocked)]
+    [InlineAutoMoqData(OrchestratorResult.Failed)]
+    public async Task Run_DoesNotStartTheServer_WhenGameSaveIsNotLoaded(
+        OrchestratorResult orchestratorResult,
+        [Frozen] Mock<ISharedSaveOrchestrator> sharedSaveOrchestratorMock,
+        [Frozen] Mock<IProcessProvider> processProviderMock,
+        GameSave gameSave,
+        Session session,
+        ServerParameters serverParameters,
+        GamingSession sut)
+    {
+        // Arrange
+        sharedSaveOrchestratorMock.Setup(x => x.Load(It.IsAny<GameSave>(), It.IsAny<Session>())).ReturnsAsync(orchestratorResult);
+
+        // Act
+        await sut.RunServerWithAutoSave(gameSave, session, serverParameters);
+        
+        // Assert
+        processProviderMock.Verify(x => x.Start(It.IsAny<ProcessStartInfo>()), Times.Never());
+    }
+
+    [Theory]
     [AutoMoqData]
     public async Task Run_DoesNotSave_WhenStartingServerFails(
         [Frozen] Mock<ISharedSaveOrchestrator> sharedSaveOrchestratorMock,
@@ -67,6 +89,9 @@ public class GamingSessionTests
         GamingSession sut)
     {
         // Arrange
+        sharedSaveOrchestratorMock
+            .Setup(x => x.Load(It.IsAny<GameSave>(), It.IsAny<Session>()))
+            .ReturnsAsync(OrchestratorResult.Loaded);
         processProviderMock.Setup(x => x.Start(It.IsAny<ProcessStartInfo>())).Throws(exception);
 
         // Act
@@ -80,12 +105,18 @@ public class GamingSessionTests
     [Theory]
     [AutoMoqData]
     public async Task Run_WaitsForServerStop_WhenServerStarts(
+        [Frozen] Mock<ISharedSaveOrchestrator> sharedSaveOrchestratorMock,
         [Frozen] Mock<IProcessProvider> processProviderMock,
         GameSave gameSave,
         Session session,
         ServerParameters serverParameters,
         GamingSession sut)
     {
+        // Arrange
+        sharedSaveOrchestratorMock
+            .Setup(x => x.Load(It.IsAny<GameSave>(), It.IsAny<Session>()))
+            .ReturnsAsync(OrchestratorResult.Loaded);
+        
         // Act
         await sut.RunServerWithAutoSave(gameSave, session, serverParameters);
 
@@ -102,6 +133,11 @@ public class GamingSessionTests
         ServerParameters serverParameters,
         GamingSession sut)
     {
+        // Arrange
+        sharedSaveOrchestratorMock
+            .Setup(x => x.Load(It.IsAny<GameSave>(), It.IsAny<Session>()))
+            .ReturnsAsync(OrchestratorResult.Loaded);
+        
         // Act
         await sut.RunServerWithAutoSave(gameSave, session, serverParameters);
 

--- a/BuddySave/Core/GamingSession.cs
+++ b/BuddySave/Core/GamingSession.cs
@@ -18,7 +18,12 @@ public class GamingSession(
             throw new ArgumentException("No server path provided. Cannot start a gaming session.");
         }
 
-        await sharedSaveOrchestrator.Load(gameSave, session);
+        var loadResult = await sharedSaveOrchestrator.Load(gameSave, session);
+        if (loadResult is not OrchestratorResult.Loaded)
+        {
+            return;
+        }
+        
         var process = StartServer(serverParameters);
         await WaitForServerToStop(process);
         await sharedSaveOrchestrator.Save(gameSave, session);

--- a/BuddySave/Core/ISharedSaveOrchestrator.cs
+++ b/BuddySave/Core/ISharedSaveOrchestrator.cs
@@ -4,7 +4,7 @@ namespace BuddySave.Core;
 
 public interface ISharedSaveOrchestrator
 {
-    Task Load(GameSave gameSave, Session session);
+    Task<OrchestratorResult> Load(GameSave gameSave, Session session);
 
     Task Save(GameSave gameSave, Session session);
 }

--- a/BuddySave/Core/Models/OrchestratorResult.cs
+++ b/BuddySave/Core/Models/OrchestratorResult.cs
@@ -1,0 +1,8 @@
+﻿namespace BuddySave.Core.Models;
+
+public enum OrchestratorResult
+{
+    Failed = 0,
+    Loaded,
+    SaveLocked
+}


### PR DESCRIPTION
Added `OrchestratorResult` that is returned from `SharedSaveOrchestrator.Load()` with values `Failed`/`Loaded`/`SaveLocked`;

I thought about solutions: 

- Move `ILockManager` to `GamingSession`. But I didn't want to duplicate the usage of `LockManager` methods as I think it's important for `SharedSaveOrchestrator` to use it as it is the one that does the actual loading/saving;
- Throw exception when save is locked in `SharedSaveOrchestrator`. But then I would have to add `try`/`catch` blocks, which would be an ugly implementation IMO;
- This solution with `OrchestratorResult`. I think this one fits best as `GameSession` now can check what result from `Load()` method and just return when the result is not that of expected.

Also - I haven't added `OrchestratorResult` to `Save()` method, because I couldn't come up with a use case ATM.

closes #29 