### PR TITLE
update: ip and port added to config, and additional information when save is locked

### DIFF
--- a/BuddySave.UnitTests/Core/SharedSaveOrchestratorTests.cs
+++ b/BuddySave.UnitTests/Core/SharedSaveOrchestratorTests.cs
@@ -24,7 +24,7 @@ public class SharedSaveOrchestratorTests
     {
         // Arrange
         lockManagerMock.Setup(x => x.LockExists(It.IsAny<GameSave>())).Returns(true);
-        lockManagerMock.Setup(x => x.GetSessionLock(It.IsAny<GameSave>())).ReturnsAsync(session);
+        lockManagerMock.Setup(x => x.GetLockedSession(It.IsAny<GameSave>())).ReturnsAsync(session);
 
         // Act
         await sut.Load(gameSave, session);
@@ -45,7 +45,7 @@ public class SharedSaveOrchestratorTests
     {
         // Arrange
         lockManagerMock.Setup(x => x.LockExists(It.IsAny<GameSave>())).Returns(true);
-        lockManagerMock.Setup(x => x.GetSessionLock(It.IsAny<GameSave>())).ReturnsAsync(session);
+        lockManagerMock.Setup(x => x.GetLockedSession(It.IsAny<GameSave>())).ReturnsAsync(session);
 
         // Act
         var result = await sut.Load(gameSave, session);

--- a/BuddySave.UnitTests/Core/SharedSaveOrchestratorTests.cs
+++ b/BuddySave.UnitTests/Core/SharedSaveOrchestratorTests.cs
@@ -24,12 +24,14 @@ public class SharedSaveOrchestratorTests
     {
         // Arrange
         lockManagerMock.Setup(x => x.LockExists(It.IsAny<GameSave>())).Returns(true);
+        lockManagerMock.Setup(x => x.GetSessionLock(It.IsAny<GameSave>())).ReturnsAsync(session);
 
         // Act
         await sut.Load(gameSave, session);
 
         // Assert
         clientNotifierMock.Verify(x => x.Notify("Game save is locked, your friends are playing!"), Times.Once);
+        clientNotifierMock.Verify(x => x.Notify($"Connect to {session.UserName}'s server using {session.Ip}:{session.Port}"), Times.Once);
         lockManagerMock.Verify(x => x.CreateLock(It.IsAny<GameSave>(), It.IsAny<Session>()), Times.Never);
         gameSaveSyncManagerMock.Verify(x => x.DownloadSave(gameSave), Times.Never);
     }
@@ -43,6 +45,7 @@ public class SharedSaveOrchestratorTests
     {
         // Arrange
         lockManagerMock.Setup(x => x.LockExists(It.IsAny<GameSave>())).Returns(true);
+        lockManagerMock.Setup(x => x.GetSessionLock(It.IsAny<GameSave>())).ReturnsAsync(session);
 
         // Act
         var result = await sut.Load(gameSave, session);

--- a/BuddySave/Core/ILockManager.cs
+++ b/BuddySave/Core/ILockManager.cs
@@ -7,6 +7,8 @@ public interface ILockManager
     bool LockExists(GameSave gameSave);
     
     Task<bool> LockExists(GameSave gameSave, Session session);
+    
+    Task<Session> GetSessionLock(GameSave gameSave);
 
     Task CreateLock(GameSave gameSave, Session session);
 

--- a/BuddySave/Core/ILockManager.cs
+++ b/BuddySave/Core/ILockManager.cs
@@ -8,7 +8,7 @@ public interface ILockManager
     
     Task<bool> LockExists(GameSave gameSave, Session session);
     
-    Task<Session> GetSessionLock(GameSave gameSave);
+    Task<Session> GetLockedSession(GameSave gameSave);
 
     Task CreateLock(GameSave gameSave, Session session);
 

--- a/BuddySave/Core/LockManager.cs
+++ b/BuddySave/Core/LockManager.cs
@@ -19,25 +19,14 @@ public class LockManager : ILockManager
             return false;
         }
 
-        var sessionLock = await GetSessionLock(lockPath);
+        var sessionLock = await GetLockedSession(lockPath);
         return string.Equals(sessionLock.UserName, session.UserName);
     }
 
-    public async Task<Session> GetSessionLock(GameSave gameSave)
+    public async Task<Session> GetLockedSession(GameSave gameSave)
     {
         var lockPath = GetLockPath(gameSave);
-        return await GetSessionLock(lockPath);
-    }
-
-    private static async Task<Session> GetSessionLock(string lockPath)
-    {
-        var jsonString = await File.ReadAllTextAsync(lockPath);
-        if (string.IsNullOrWhiteSpace(jsonString))
-        {
-            throw new Exception("Cannot get session details from lock. Lock file is empty");
-        }
-
-        return JsonSerializer.Deserialize<Session>(jsonString)!;
+        return await GetLockedSession(lockPath);
     }
 
     public async Task CreateLock(GameSave gameSave, Session session)
@@ -57,7 +46,7 @@ public class LockManager : ILockManager
             return;
         }
 
-        var sessionLock = await GetSessionLock(lockPath);
+        var sessionLock = await GetLockedSession(lockPath);
         if (!string.Equals(session.UserName, sessionLock.UserName))
         {
             throw new Exception($"Cannot delete lock. Lock is owned by {sessionLock.UserName}.");
@@ -69,5 +58,16 @@ public class LockManager : ILockManager
     private static string GetLockPath(GameSave gameSave)
     {
         return gameSave.CloudPath + ".lock";
+    }
+
+    private static async Task<Session> GetLockedSession(string lockPath)
+    {
+        var jsonString = await File.ReadAllTextAsync(lockPath);
+        if (string.IsNullOrWhiteSpace(jsonString))
+        {
+            throw new Exception("Cannot get session details from lock. Lock file is empty");
+        }
+
+        return JsonSerializer.Deserialize<Session>(jsonString)!;
     }
 }

--- a/BuddySave/Core/Models/Session.cs
+++ b/BuddySave/Core/Models/Session.cs
@@ -1,6 +1,10 @@
 ﻿namespace BuddySave.Core.Models;
 
-public class Session
+public class Session(string userName, string ip, string port)
 {
-    public string UserName { get; set; }
+    public string UserName { get; init; } = userName;
+
+    public string Ip { get; init; } = ip;
+
+    public string Port { get; init; } = port;
 }

--- a/BuddySave/Core/SharedSaveOrchestrator.cs
+++ b/BuddySave/Core/SharedSaveOrchestrator.cs
@@ -16,7 +16,9 @@ public class SharedSaveOrchestrator(
         OrchestratorResult result;
         if (lockManager.LockExists(gameSave))
         {
+            var sessionLock = await lockManager.GetSessionLock(gameSave);
             clientNotifier.Notify("Game save is locked, your friends are playing!");
+            clientNotifier.Notify($"Connect to {sessionLock.UserName}'s server using {sessionLock.Ip}:{sessionLock.Port}");
             return OrchestratorResult.SaveLocked;
         }
 

--- a/BuddySave/Core/SharedSaveOrchestrator.cs
+++ b/BuddySave/Core/SharedSaveOrchestrator.cs
@@ -16,7 +16,7 @@ public class SharedSaveOrchestrator(
         OrchestratorResult result;
         if (lockManager.LockExists(gameSave))
         {
-            var sessionLock = await lockManager.GetSessionLock(gameSave);
+            var sessionLock = await lockManager.GetLockedSession(gameSave);
             clientNotifier.Notify("Game save is locked, your friends are playing!");
             clientNotifier.Notify($"Connect to {sessionLock.UserName}'s server using {sessionLock.Ip}:{sessionLock.Port}");
             return OrchestratorResult.SaveLocked;

--- a/BuddySave/config.example.json
+++ b/BuddySave/config.example.json
@@ -6,7 +6,7 @@
     "Port": "2456"
   },
   "ServerParameters":{
-    "Path": "C:\\Program Files\\Steam\\steamapps\\common\Valheim dedicated server\\start_headless_server.bat",
+    "Path": "C:\\Program Files\\Steam\\steamapps\\common\\Valheim dedicated server\\start_headless_server.bat",
     "Arguments": ""
   },
   "GameSave": {

--- a/BuddySave/config.example.json
+++ b/BuddySave/config.example.json
@@ -1,7 +1,9 @@
 ﻿{
   "CloudPath": "C:\\GoogleDrive\\BuddySave",
   "Session": {
-    "UserName": "buddy"
+    "UserName": "buddy",
+    "Ip": "127.0.0.1",
+    "Port": "2456"
   },
   "ServerParameters":{
     "Path": "C:\\Program Files\\Steam\\steamapps\\common\Valheim dedicated server\\start_headless_server.bat",


### PR DESCRIPTION
update: 
* added ip and port to config; 
* when game save is locked user now will be displayed a message of the owner and the ip:port to connect to;

**! this is a breaking change for config.json !**

I was also thinking of resolving the IP address in code, but that would require to depend on external recourses, which is most commonly calling one of the "what's my ip" websites. To me it's a very hard and unstable dependency, that I think is not really worth having.

closes #38 
closes #31 
